### PR TITLE
Conceal terminal color escape codes

### DIFF
--- a/syntax/log.vim
+++ b/syntax/log.vim
@@ -152,6 +152,10 @@ hi def link logLevelInfo Repeat
 hi def link logLevelDebug Debug
 hi def link logLevelTrace Comment
 
+" Conceal Terminal Color Escape Codes
+"---------------------------------------------------------------------------
+syntax match Normal '\[[0-9;]*m' conceal
+setlocal conceallevel=3
 
 
 let b:current_syntax = 'log'

--- a/syntax/log.vim
+++ b/syntax/log.vim
@@ -155,7 +155,8 @@ hi def link logLevelTrace Comment
 " Conceal Terminal Color Escape Codes
 "---------------------------------------------------------------------------
 syntax match Normal '\[[0-9;]*m' conceal
-setlocal conceallevel=3
+setlocal conceallevel=2
+setlocal concealcursor=n
 
 
 let b:current_syntax = 'log'


### PR DESCRIPTION
This adds 

```vimscript
syntax match Normal '\[[0-9;]*m' conceal
```

To conceal all ANSI color code escape sequences, so they do not distract you from reading the logs.

It also sets `conceallevel` and `concealcursor` so color escape codes are completely hidden unless in `VISUAL` or `INSERT` mode (like Vim's help files).