### PR TITLE
Extend logTime to nanosecond precision

### DIFF
--- a/syntax/log.vim
+++ b/syntax/log.vim
@@ -47,8 +47,8 @@ syn match logDate '^20\d\{6}'
 syn keyword logDate Mon Tue Wed Thu Fri Sat Sun Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec nextgroup=logDateDay
 syn match logDateDay '\s\{1,2}\d\{1,2}' contained
 
-" Matches 12:09:38 or 00:03:38.129Z or 01:32:12.102938 +0700
-syn match logTime '\d\{2}:\d\{2}:\d\{2}\(\.\d\{2,6}\)\?\(\s\?[-+]\d\{2,4}\|Z\)\?\>' nextgroup=logTimeZone,logSysColumns skipwhite
+" Matches 12:09:38 or 00:03:38.129Z or 01:32:12.102938 +0700 or 01:32:12.123456789
+syn match logTime '\d\{2}:\d\{2}:\d\{2}\(\.\d\{2,9}\)\?\(\s\?[-+]\d\{2,4}\|Z\)\?\>' nextgroup=logTimeZone,logSysColumns skipwhite
 
 " Follows logTime, matches UTC or PDT 2019 or 2019 EDT
 syn match logTimeZone '[A-Z]\{2,5}\>\( \d\{4}\)\?' contained


### PR DESCRIPTION
Hello! Thanks for the handy syntax file.

These days I'm mostly looking at logs from Kubenetes pods. Using `kubectl` you can specify the `--timestamps=true` flag which will prefix all log entries with the timestamp they were recorded. Anyway this seems to be at nanosecond granularity, e.g. 

```
2023-08-17T07:52:26.131134150Z Generating output directory: dist/
2023-08-17T07:52:26.144996867Z Full static mode activated
2023-08-17T07:52:26.146209081Z Generating pages
```

This change just extends the `logTime` regex up to 9 digits. Please consider merging it in, many thanks!