### PR TITLE
#19 Fix RFC 3339/ISO 8601 dates

### DIFF
--- a/syntax/log.vim
+++ b/syntax/log.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:         Generic log file
 " Maintainer:       MTDL9 <https://github.com/MTDL9>
-" Latest Revision:  2020-08-23
+" Latest Revision:  2023-11-27
 
 if exists('b:current_syntax')
   finish
@@ -39,16 +39,16 @@ syn region logString      start=/'\(s \|t \| \w\)\@!/ end=/'/ end=/$/ end=/s / s
 
 " Dates and Times
 "---------------------------------------------------------------------------
-" Matches 2018-03-12T or 12/03/2018 or 12/Mar/2018
-syn match logDate '\d\{2,4}[-\/]\(\d\{2}\|Jan\|Feb\|Mar\|Apr\|May\|Jun\|Jul\|Aug\|Sep\|Oct\|Nov\|Dec\)[-\/]\d\{2,4}T\?'
+" Matches 2018-03-12T or 12/03/2018 or 12/Mar/2018 or 27 Nov 2023
+syn match logDate '\d\{2,4}[-\/ ]\(\d\{2}\|Jan\|Feb\|Mar\|Apr\|May\|Jun\|Jul\|Aug\|Sep\|Oct\|Nov\|Dec\)[-\/ ]\d\{2,4}T\?'
 " Matches 8 digit numbers at start of line starting with 20
 syn match logDate '^20\d\{6}'
 " Matches Fri Jan 09 or Feb 11 or Apr  3 or Sun 3
 syn keyword logDate Mon Tue Wed Thu Fri Sat Sun Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec nextgroup=logDateDay
 syn match logDateDay '\s\{1,2}\d\{1,2}' contained
 
-" Matches 12:09:38 or 00:03:38.129Z or 01:32:12.102938 +0700
-syn match logTime '\d\{2}:\d\{2}:\d\{2}\(\.\d\{2,6}\)\?\(\s\?[-+]\d\{2,4}\|Z\)\?\>' nextgroup=logTimeZone,logSysColumns skipwhite
+" Matches 12:09:38 or 00:03:38.129Z or 01:32:12.102938 +0700 or 21:14:18+11:00
+syn match logTime '\d\{2}:\d\{2}:\d\{2}\(\.\d\{2,6}\)\?\(\s\?[-+]\(\d\{1,2\}:\d\{2\}\|\d\{2,4}\)\|Z\)\?\>' nextgroup=logTimeZone,logSysColumns skipwhite
 
 " Follows logTime, matches UTC or PDT 2019 or 2019 EDT
 syn match logTimeZone '[A-Z]\{2,5}\>\( \d\{4}\)\?' contained


### PR DESCRIPTION
Fix RFC 3339 dates, and ISO 8601 dates with colons in time zone offsets.